### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,15 +2,26 @@
 # Dockerfile to build a sample tool container for BAMStats
 #############################################################
 
-# Set the base image to Ubuntu
-FROM ubuntu:14.04
+# set the base image to a version of Ubuntu with LTS
+FROM ubuntu:22.04
 
-# File Author / Maintainer
-MAINTAINER Brian OConnor <briandoconnor@gmail.com>
+# two different ways of declaring authorship
+LABEL maintainer="aofarrel@ucsc.edu"
+LABEL org.opencontainers.image.authors="Brian O'Connor <briandoconnor@gmail.com>, Ash O'Farrell <aofarrel@ucsc.edu>"
 
-# Setup packages
+# setup packages
+# software-properties-common: needed to add openjdk repository
+# openjdk 11: needed by bamstats
+# wget: needed to download bamstats
+# unzip: needed to install bamstats
+# zip: needed to handle bamstats output
 USER root
-RUN apt-get -m update && apt-get install -y wget unzip openjdk-7-jre zip
+RUN apt-get -m update && \
+    apt-get install -y software-properties-common && \
+    add-apt-repository ppa:openjdk-r/ppa && apt-get update -q && apt install -y openjdk-11-jdk && \
+    apt-get install -y wget && \
+    apt-get install -y unzip && \
+    apt-get install -y zip
 
 # get the tool and install it in /usr/local/bin
 RUN wget -q http://downloads.sourceforge.net/project/bamstats/BAMStats-1.25.zip
@@ -24,5 +35,5 @@ RUN chmod a+x /usr/local/bin/bamstats
 RUN groupadd -r -g 1000 ubuntu && useradd -r -g ubuntu -u 1000 -m ubuntu
 USER ubuntu
 
-# by default /bin/bash is executed
+# by default, /bin/bash is executed
 CMD ["/bin/bash"]


### PR DESCRIPTION
* Ubuntu 14.04 has LTS, but not for much longer; might as well move on to a newer LTS
* MAINTAINER is deprecated in favor of LABEL; there isn't a very clear standard for LABEL so I included what seem to the most common schemas
* Add software-properties-common, unzip, zip, and wget as they apparently are not included in the base image? Like, without these it's a bunch of `command not found` but since the older versions didn't need these installations this feels incorrect. Hmmm. Any ideas, folks?

When running via the command line, the output visually appears to match the output of the older version, down to the odd-looking whisker plot on the summary HTML page. I've attached outputs from both the previous Tahr-based Docker and the new one in this PR.
* new: [bamstats_report-jammy.zip](https://github.com/dockstore/dockstore-tool-bamstats/files/8912806/bamstats_report-jammy.zip)
* old: [bamstats_report-trusty.zip](https://github.com/dockstore/dockstore-tool-bamstats/files/8912807/bamstats_report-trusty.zip)
