### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,12 @@
 [![Docker Repository on Quay.io](https://quay.io/repository/collaboratory/dockstore-tool-bamstats/status "Docker Repository on Quay.io")](https://quay.io/repository/collaboratory/dockstore-tool-bamstats)
-[![Build Status](https://travis-ci.org/CancerCollaboratory/dockstore-tool-bamstats.svg)](https://travis-ci.org/CancerCollaboratory/dockstore-tool-bamstats)
 
 # dockstore-tool-bamstats
 
-A repo for the `Dockerfile` to create a Docker image for the BAMStats command. Also contains the
-`Dockstore.yml` which is used by the [Dockstore](https://www.dockstore.org) to register
-this container and describe how to call BAMStats for the community.
+A repo for the `Dockerfile` to create a Docker image for the BAMStats command.
 
 ## Validation 
 
-This tool has been validated as a CWL draft-3 and v1.0 CommandLineTool. 
+The CWL version of this tool has been validated as a CWL draft-3 and v1.0 CommandLineTool. 
 
 Versions that we tested with are the following 
 ```
@@ -33,82 +30,6 @@ manually you would execute:
 
 ```
 $ wget ftp://ftp.1000genomes.ebi.ac.uk/vol1/ftp/phase3/data/NA12878/alignment/NA12878.chrom20.ILLUMINA.bwa.CEU.low_coverage.20121211.bam
-$ docker run -it -v `pwd`/NA12878.chrom20.ILLUMINA.bwa.CEU.low_coverage.20121211.bam:/NA12878.chrom20.ILLUMINA.bwa.CEU.low_coverage.20121211.bam collaboratory/dockstore-tool-bamstats:1.25-3
-
-# within the docker container
-$ /usr/local/bin/bamstats 4 /NA12878.chrom20.ILLUMINA.bwa.CEU.low_coverage.20121211.bam
+$ docker run -w="/home/ubuntu" -v `pwd`:/home/ubuntu --user `echo $UID`:1000 quay.io/collaboratory/dockstore-tool-bamstats:1.25-6 bamstats 4 NA12878.chrom20.ILLUMINA.bwa.CEU.low_coverage.20121211.bam
 ```
-You'll then see a file, `bamstats_report.zip`, in the current directory, that's the report file. You can use `-v` to mount the result out of the container.
-
-## Running Through the Dockstore CLI
-
-This tool can be found at the [Dockstore](https://dockstore.org), login with your GitHub account and follow the 
-directions to setup the CLI.  It lets you run a Docker container with a CWL/WDL descriptor locally, using Docker and the CWL/WDL command line utility.  This is great for testing.
-
-### With CWL
-
-#### Make a Parameters JSON
-
-This is the parameterization of the BAM stat tool, a copy is present in this repo called `sample_configs.json`:
-
-```
-{
-  "bam_input": {
-        "class": "File",
-        "path": "ftp://ftp.1000genomes.ebi.ac.uk/vol1/ftp/phase3/data/NA12878/alignment/NA12878.chrom20.ILLUMINA.bwa.CEU.low_coverage.20121211.bam"
-    },
-    "bamstats_report": {
-        "class": "File",
-        "path": "/tmp/bamstats_report.zip"
-    }
-}
-```
-
-#### Run with the CLI
-
-Run it using the `dockstore` CLI:
-
-```
-Usage:
-# fetch CWL
-$> dockstore tool cwl --entry quay.io/collaboratory/dockstore-tool-bamstats:1.25-3 > Dockstore.cwl
-# make a runtime JSON template and edit it (or use the content of sample_configs.json above)
-$> dockstore tool convert cwl2json --cwl Dockstore.cwl > Dockstore.json
-# run it locally with the Dockstore CLI
-$> dockstore tool launch --entry quay.io/collaboratory/dockstore-tool-bamstats:1.25-3 --json Dockstore.json
-```
-
-### With WDL
-#### Make a Parameters JSON
-
-This is the parameterization of the BAM stat tool, a copy is present in this repo called `test.wdl.json`:
-
-```
-{
-  "bamstatsWorkflow.bam_input": "rna.SRR948778.bam",
-  "bamstatsWorkflow.mem_gb": "4"
-}
-```
-
-#### Run with the CLI
-
-Run it using the `dockstore` CLI:
-
-```
-Usage:
-# fetch WDL
-$> dockstore tool wdl --entry quay.io/collaboratory/dockstore-tool-bamstats > Dockstore.wdl
-# make a runtime JSON template and edit it (or use the content of test.wdl.json above)
-$> dockstore tool convert wdl2json --wdl Dockstore.wdl > Dockstore.json
-# run it locally with the Dockstore CLI
-$> dockstore tool launch --entry quay.io/collaboratory/dockstore-tool-bamstats --json Dockstore.json
-```
-
-## Running Nextflow Workflow
-
-Install [Nextflow](https://www.nextflow.io/). Nextflow workflows cannot be run with the Dockstore CLI yet.
-
-The workflow can be run using the following command:
-```
-$> nextflow run main.nf
-```
+You'll then see a file, `bamstats_report.zip`. Using the command above, it will automatically be mounted out of the container.


### PR DESCRIPTION
* Remove Travis CI shield
* Replace Docker command with a better one
* Remove non-functional Dockstore CLI instructions (I did some tinkering to see if I could get this to work but it seems the CWL is out of date, and it doesn't like the WDL either)

Would be willing to revert the deletion of of the Dockstore CLI stuff once the CWL is fixed.